### PR TITLE
fix: Draw image on canvas after size changes

### DIFF
--- a/src/maskEditor.tsx
+++ b/src/maskEditor.tsx
@@ -59,16 +59,20 @@ export const MaskEditor: React.FC<MaskEditorProps> = (props: MaskEditorProps) =>
     }
   }, [cursorCanvas]);
 
+  const [image, setImage] = React.useState<HTMLImageElement>();
   React.useEffect(() => {
-    if (src && context) {
-      const img = new Image;
-      img.onload = evt => {
-        setSize({x: img.width, y: img.height});
-        context?.drawImage(img, 0, 0);
-      }
-      img.src = src;
-    }
-  }, [src, context]);
+    const img = new Image();
+    img.onload = (evt) => {
+      setSize({ x: img.width, y: img.height });
+      context?.drawImage(img, 0, 0);
+    };
+    img.src = src;
+    setImage(img);
+  }, [src]);
+
+  React.useEffect(() => {
+    context?.drawImage(img!, 0, 0);
+  }, [size, image]);
 
   // Pass mask canvas up
   React.useLayoutEffect(() => {

--- a/src/maskEditor.tsx
+++ b/src/maskEditor.tsx
@@ -71,7 +71,8 @@ export const MaskEditor: React.FC<MaskEditorProps> = (props: MaskEditorProps) =>
   }, [src]);
 
   React.useEffect(() => {
-    context?.drawImage(img!, 0, 0);
+    if (!image) return;
+    context?.drawImage(image, 0, 0);
   }, [size, image]);
 
   // Pass mask canvas up


### PR DESCRIPTION
I encountered an error where the canvas was consistently empty. I tracked it down to this bug where the canvas loses its drawn image when resized. A quick example via codepen:

* Broken: Draw image before resize - https://codepen.io/alukach/pen/ZEZJBKv
* Working: Draw image after resize - https://codepen.io/alukach/pen/bGJrBge

The fix is to break out the drawImage step into a separate effect that runs on resize or when the image changes.